### PR TITLE
fixed dimensions of attention mask in get_uptake_prediction

### DIFF
--- a/edu_convokit/annotation/annotator.py
+++ b/edu_convokit/annotation/annotator.py
@@ -324,7 +324,7 @@ class Annotator:
         )
 
     def _get_uptake_prediction(self, model, device, instance):
-        instance["attention_mask"] = [[1] * len(instance["input_ids"])]
+        instance["attention_mask"] = [1] * len(instance["input_ids"])
         for key in ["input_ids", "token_type_ids", "attention_mask"]:
             instance[key] = torch.tensor(instance[key]).unsqueeze(0)  # Batch size = 1
             instance[key] = instance[key].to(device)


### PR DESCRIPTION
When we ran get_uptake() we get an error (too many values to unpack (expected 2)), this is because the extra brackets around the attention mask was creating an input of the wrong dimension. This PR removes the outer brackets to make sure that we get the correct dimension size. 